### PR TITLE
Network Profile Link+Chat Profile Link script: Adds chat profile link to Profiles dropdown

### DIFF
--- a/add-network-profile-link/add-network-profile-link.user.js
+++ b/add-network-profile-link/add-network-profile-link.user.js
@@ -66,16 +66,16 @@
     switch (location.host) {
       case 'meta.stackexchange.com':
         chatHost = 'chat.meta.stackexchange.com';
-        chatLogo = '<div class="favicon favicon-stackexchangemeta"></div>';
+        chatLogo = '<div class="favicon favicon-stackexchangemeta"/>';
         break;
       case 'stackoverflow.com':
       case 'meta.stackoverflow.com':
         chatHost = 'chat.stackoverflow.com';
-        chatLogo = '<div class="favicon favicon-stackoverflow"></div>';
+        chatLogo = '<div class="favicon favicon-stackoverflow"/>';
         break;
       default:
         chatHost = 'chat.stackexchange.com';
-        chatLogo = '<div class="favicon favicon-stackexchangemeta"></div>';
+        chatLogo = '<div class="favicon favicon-stackexchangemeta"/>';
         break;
     }
     // If the profile has a dropdown available, insert the link as an item in the dropdown list

--- a/add-network-profile-link/add-network-profile-link.user.js
+++ b/add-network-profile-link/add-network-profile-link.user.js
@@ -61,21 +61,37 @@
     }
     
     // Add link to chat profile
-    // NICETOHAVE: add as part of dropdown menu
     var chatHost;
+    var chatLogo;
     switch (location.host) {
       case 'meta.stackexchange.com':
         chatHost = 'chat.meta.stackexchange.com';
+        chatLogo = '<div class="favicon favicon-stackexchangemeta"></div>';
         break;
       case 'stackoverflow.com':
       case 'meta.stackoverflow.com':
         chatHost = 'chat.stackoverflow.com';
+        chatLogo = '<div class="favicon favicon-stackoverflow"></div>';
         break;
       default:
         chatHost = 'chat.stackexchange.com';
+        chatLogo = '<div class="favicon favicon-stackexchangemeta"></div>';
         break;
     }
-    existingButton.before('<a class="flex--item s-btn s-btn__outlined s-btn__muted s-btn__icon s-btn__sm" href="https://' + chatHost + '/account/' + accountID + '" class="d-flex ai-center ws-nowrap s-btn s-btn__outlined s-btn__muted s-btn__icon s-btn__sm d-flex ai-center">\n' +
+    // If the profile has a dropdown available, insert the link as an item in the dropdown list
+    if(existingButton[0].classList.contains('s-btn__dropdown')) {
+        let profileItems = $('#profiles-menu').find('.s-menu');
+        let teamsSeparatorIndex = profileItems.find('.s-menu--title').index();
+        if(teamsSeparatorIndex > -1) {
+            profileItems.find('li').eq(teamsSeparatorIndex ).before('<li role="menuitem" id="chatprofile"><a href="https://' + chatHost + '/account/' + accountID + '" class="s-block-link d-flex ai-center ws-nowrap">' + chatLogo + '  Chat profile</a></li>');
+        }
+        else {
+            profileItems.append('<li role="menuitem" id="chatprofile"><a href="https://' + chatHost + '/account/' + accountID + '" class="s-block-link d-flex ai-center ws-nowrap">' + chatLogo + '  Chat profile</a></li>');
+        }
+    }
+    else {
+        existingButton.before('<a class="flex--item s-btn s-btn__outlined s-btn__muted s-btn__icon s-btn__sm" href="https://' + chatHost + '/account/' + accountID + '" class="d-flex ai-center ws-nowrap s-btn s-btn__outlined s-btn__muted s-btn__icon s-btn__sm d-flex ai-center">\n' +
         'Chat profile</a>');
+    }
   });
 })();


### PR DESCRIPTION
Saw that there was a "NICETOHAVE" and figured I could resolve it.

This changes the "Chat profile" link to instead be in the "Profiles" dropdown if the profile you're looking at has a dropdown. (I.e. they're not on Meta SE or somewhere where the profiles dropdown isn't generated)

This link is inserted before the "Teams" list item separator if it exists, and at the bottom of the list of profile items if it doesn't. It uses the chat server's logo (defaults to Meta SE's logo) which is displayed next to the text for uniformity.

Here's how it looks for someone else for me:

![other person's profile](https://i.imgur.com/xatAY6o.png)

And here's how it looks for my own profile (I'm on the Charcoal team):

![my profile](https://i.imgur.com/CYCMji6.png)

Should you merge this, you should update [your recently-posted answer here](https://meta.stackexchange.com/a/377775/622284) as well as bump the version on this script.

🆑
- Moves "Chat profile" link into the list of list items if the "Profiles" dropdown exists.
- Removes "NICETOHAVE" comment
/🆑